### PR TITLE
add overflow detection to ethmarks-footer component

### DIFF
--- a/layouts/partials/ethmarks-components-js.html
+++ b/layouts/partials/ethmarks-components-js.html
@@ -12,6 +12,32 @@ class EthmarksHeader extends HTMLElement {
 class EthmarksFooter extends HTMLElement {
   connectedCallback() {
     this.innerHTML = %s;
+
+    // Add overflow detection functionality
+    function updateOverflowClasses() {
+      const heightOverflowClass = "height-overflow";
+      const body = document.body;
+      const containerHeight = window.innerHeight;
+      const contentHeight = Math.max(
+        document.documentElement.scrollHeight,
+        document.body.scrollHeight
+      );
+
+      if (contentHeight === 0) { return; }
+
+      if (contentHeight > containerHeight) {
+        body.classList.add(heightOverflowClass);
+      } else {
+        body.classList.remove(heightOverflowClass);
+      }
+    }
+
+    const resizeObserver = new ResizeObserver(() => {
+      updateOverflowClasses();
+    });
+
+    resizeObserver.observe(document.body);
+    updateOverflowClasses();
   }
 }
 


### PR DESCRIPTION
Add a script to ethmarks-footer that handles height overflow.

<table>
<thead>
  <tr>
    <th>Old</th>
    <th>New</th>
  </tr>
</thead>
<body>
  <tr>
    <td>
      <img width="1920" height="938" alt="Screenshot 2025-10-04 at 15-27-39 Components Test" src="https://github.com/user-attachments/assets/5f4bd409-3ce9-4f1f-bf9a-8babbdf66e8f" />
    </td>
    <td>
      <img width="1920" height="938" alt="Screenshot 2025-10-04 at 15-27-13 Components Test" src="https://github.com/user-attachments/assets/daf72168-227a-4ae6-92ec-181e0abf169c" />
    </td>
  </tr>
</body>
</table>


